### PR TITLE
chore(deps): bump deps, drop old Python / Django support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = open('README.rst').read()
 
 setup(
     name='djapi',
-    version='0.2',
+    version='0.3',
     author='Alexander Schepanovski',
     author_email='suor.web@gmail.com',
 
@@ -17,25 +17,23 @@ setup(
 
     packages=find_packages(),
     install_requires=[
-        'django>=2.1',
-        'funcy>=1.8,<2.0',
-        'six>=1.10.0',
+        'django>=3.2',
+        'funcy>=1.8,<3.0',
     ],
     classifiers=[
         'Development Status :: 4 - Beta',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.23',
         'Framework :: Django',
-        'Framework :: Django :: 2.1',
-        'Framework :: Django :: 2.2',
-        'Framework :: Django :: 3.0',
+        'Framework :: Django :: 3.2',
+        'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.0',
 
         'Environment :: Web Environment',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Old deps prevent us an upgrade to funcy 2.

Tested with Studio (Django 4, Python 11, funcy 2).